### PR TITLE
Update dashboard_topnav.html

### DIFF
--- a/src/app/partials/dashboard_topnav.html
+++ b/src/app/partials/dashboard_topnav.html
@@ -32,9 +32,6 @@
 						</li>
 
 						<li>
-							<a class="link" ng-click="set_default()">Save as Home</a>
-						</li>
-						<li>
 							<a class="link" ng-click="purge_default()">Reset Home</a>
 						</li>
 						<li ng-show="!isFavorite">


### PR DESCRIPTION
Monasca doesn't seem to really support the ability to save a dashboard as the home dashboard, and this option consistently errors out.

Until this is properly supported, I'd propose it gets removed.
