### PR TITLE
Update monDatasource.js

### DIFF
--- a/src/app/services/mon/monDatasource.js
+++ b/src/app/services/mon/monDatasource.js
@@ -176,7 +176,11 @@ function (angular, _, kbn) {
           options.url = currentUrl + '/metrics/statistics';
         }
 
-        return $http(options).success(function (data) {
+        return $http(options).success(function (data, status, headers, config) {
+          if (headers('Content-Type').indexOf("text/html") != -1){
+            window.location =  window.location.origin;
+            return;
+          }
           data.alias = alias;
           data.label = label;
           data.startTime = startTime;
@@ -217,7 +221,11 @@ function (angular, _, kbn) {
           headers: headers
         };
 
-        return $http(options).success(function (data) {
+        return $http(options).success(function (data, status, headers, config) {
+          if (headers('Content-Type').indexOf("text/html") != -1){
+            window.location =  window.location.origin;
+            return;
+          }
           data.alias = alias;
           deferred.resolve(data);
         });


### PR DESCRIPTION
This change will cause the browser to navigate back to root url when the login page comes back up (token expires).   This helps by keeping the constant invalid requests to a minimum.
